### PR TITLE
Improve Matrix RREF Implementation

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -12,4 +12,6 @@ var (
 	ErrBadPieceCount                     = errors.New("minimum 2 pieces required for RLNC")
 	ErrCodedDataLengthMismatch           = errors.New("coded data length != coded piece count x coded piece length")
 	ErrCodingVectorLengthMismatch        = errors.New("coding vector length > coded piece length ( in total )")
+	ErrPieceNotDecodedYet                = errors.New("piece not decoded yet, more pieces required")
+	ErrPieceOutOfBound                   = errors.New("requested piece index >= pieceCount ( pieces coded together )")
 )

--- a/full/decoder.go
+++ b/full/decoder.go
@@ -7,17 +7,21 @@ import (
 )
 
 type FullRLNCDecoder struct {
-	expected uint
-	useful   uint
-	received uint
-	field    *galoisfield.GF
-	pieces   []*kodr.CodedPiece
-	rref     matrix.Matrix
+	expected, useful, received uint
+	state                      *matrix.DecoderState
 }
 
 // PieceLength - Returns piece length in bytes
+//
+// If no pieces are yet added to decoder state, then
+// returns 0, denoting **unknown**
 func (d *FullRLNCDecoder) PieceLength() uint {
-	return uint(len(d.pieces[0].Piece))
+	if d.received > 0 {
+		coded := d.state.CodedPieceMatrix()
+		return coded.Cols()
+	}
+
+	return 0
 }
 
 // IsDecoded - Use it for checking whether more piece
@@ -40,45 +44,38 @@ func (d *FullRLNCDecoder) Required() uint {
 // augmented matrix ( coding vector + coded piece )
 // is rref-ed, to keep it as ready as possible for consuming
 // decoded pieces
+//
+// Note: As soon as all pieces are decoded, no more calls to
+// this method does anything useful --- so better check for error & proceed !
 func (d *FullRLNCDecoder) AddPiece(piece *kodr.CodedPiece) error {
-	d.pieces = append(d.pieces, piece)
-	d.received++
-	if !(d.received > 1) {
-		d.useful++
-		return nil
-	}
-	// no more piece collection is required, decoding
-	// has been performed successfully
-	//
 	// good time to start reading decoded pieces
 	if d.IsDecoded() {
 		return kodr.ErrAllUsefulPiecesReceived
 	}
 
-	if d.rref == nil {
-		rref := make(matrix.Matrix, d.received)
-		for i := range rref {
-			rref[i] = d.pieces[i].Flatten()
-		}
-
-		d.rref = rref
-	} else {
-		d.rref = append(d.rref, piece.Flatten())
+	d.state.AddPiece(piece)
+	d.received++
+	if !(d.received > 1) {
+		d.useful++
+		return nil
 	}
 
-	d.rref.Rref(d.field)
-	d.useful = d.rref.Rank_()
+	d.state.Rref()
+	d.useful = d.state.Rank()
 	return nil
 }
 
-// GetPiece - Get a decoded piece by index, given full
-// decoding has happened
+// GetPiece - Get a decoded piece by index, may ( not ) succeed !
+//
+// Note: It's not necessary that full decoding needs to happen
+// for this method to return something useful
+//
+// If M-many pieces are received among N-many expected ( read M <= N )
+// then pieces with index in [0..M] ( remember upper bound exclusive )
+// can be attempted to be consumed, given algebric structure has revealed
+// requested piece at index `i`
 func (d *FullRLNCDecoder) GetPiece(i uint) (kodr.Piece, error) {
-	if !d.IsDecoded() || i >= d.useful {
-		return nil, kodr.ErrMoreUsefulPiecesRequired
-	}
-
-	return d.rref[i][uint(len(d.rref[i]))-d.PieceLength():], nil
+	return d.state.GetPiece(i)
 }
 
 // GetPieces - Get a list of all decoded pieces, given full
@@ -107,5 +104,7 @@ func (d *FullRLNCDecoder) GetPieces() ([]kodr.Piece, error) {
 // which is generally equal to original #-of pieces, decoded pieces
 // can be read back
 func NewFullRLNCDecoder(pieceCount uint) *FullRLNCDecoder {
-	return &FullRLNCDecoder{expected: pieceCount, field: galoisfield.DefaultGF256, pieces: make([]*kodr.CodedPiece, 0)}
+	gf := galoisfield.DefaultGF256
+	state := matrix.NewDecoderStateWithPieceCount(gf, pieceCount)
+	return &FullRLNCDecoder{expected: pieceCount, state: state}
 }

--- a/full/decoder.go
+++ b/full/decoder.go
@@ -87,9 +87,12 @@ func (d *FullRLNCDecoder) GetPieces() ([]kodr.Piece, error) {
 
 	pieces := make([]kodr.Piece, 0, d.useful)
 	for i := 0; i < int(d.useful); i++ {
-		// safe to ignore error, because I've
-		// already checked it above
-		piece, _ := d.GetPiece(uint(i))
+		// error mustn't happen at this point, it should
+		// have been returned fromvery first `if-block` in function
+		piece, err := d.GetPiece(uint(i))
+		if err != nil {
+			return nil, err
+		}
 		pieces = append(pieces, piece)
 	}
 	return pieces, nil

--- a/matrix/decoder_state.go
+++ b/matrix/decoder_state.go
@@ -1,0 +1,177 @@
+package matrix
+
+import (
+	"github.com/cloud9-tools/go-galoisfield"
+)
+
+type DecoderState struct {
+	field  *galoisfield.GF
+	coeffs Matrix
+	coded  Matrix
+}
+
+func min(a, b int) int {
+	if a <= b {
+		return a
+	}
+	return b
+}
+
+func (d *DecoderState) clean_forward() {
+	var (
+		rows     int = int(d.coeffs.Rows())
+		cols     int = int(d.coeffs.Cols())
+		boundary int = min(rows, cols)
+	)
+
+	for i := 0; i < boundary; i++ {
+		if d.coeffs[i][i] == 0 {
+			non_zero_col := false
+			pivot := i + 1
+			for ; pivot < rows; pivot++ {
+				if d.coeffs[pivot][i] != 0 {
+					non_zero_col = true
+					break
+				}
+			}
+
+			if !non_zero_col {
+				continue
+			}
+
+			tmp := d.coeffs[i]
+			d.coeffs[i] = d.coeffs[pivot]
+			d.coeffs[pivot] = tmp
+		}
+
+		for j := i + 1; j < rows; j++ {
+			if d.coeffs[j][i] == 0 {
+				continue
+			}
+
+			quotient := d.field.Div(d.coeffs[j][i], d.coeffs[i][i])
+			for k := i; k < cols; k++ {
+				d.coeffs[j][k] = d.field.Add(d.coeffs[j][k], d.field.Mul(d.coeffs[i][k], quotient))
+			}
+
+			for k := 0; k < int(d.coded.Cols()); k++ {
+				d.coded[j][k] = d.field.Add(d.coded[j][k], d.field.Mul(d.coded[i][k], quotient))
+			}
+		}
+	}
+}
+
+func (d *DecoderState) clean_backward() {
+	var (
+		rows     int = int(d.coeffs.Rows())
+		cols     int = int(d.coeffs.Cols())
+		boundary int = min(rows, cols)
+	)
+
+	for i := boundary - 1; i >= 0; i-- {
+		if d.coeffs[i][i] == 0 {
+			continue
+		}
+
+		for j := 0; j < i; j++ {
+			if d.coeffs[j][i] == 0 {
+				continue
+			}
+
+			quotient := d.field.Div(d.coeffs[j][i], d.coeffs[i][i])
+			for k := i; k < cols; k++ {
+				d.coeffs[j][k] = d.field.Add(d.coeffs[j][k], d.field.Mul(d.coeffs[i][k], quotient))
+			}
+
+			for k := 0; k < int(d.coded.Cols()); k++ {
+				d.coded[j][k] = d.field.Add(d.coded[j][k], d.field.Mul(d.coded[i][k], quotient))
+			}
+
+		}
+
+		if d.coeffs[i][i] == 1 {
+			continue
+		}
+
+		inv := d.field.Div(1, d.coeffs[i][i])
+		d.coeffs[i][i] = 1
+		for j := i + 1; j < cols; j++ {
+			if d.coeffs[i][j] == 0 {
+				continue
+			}
+
+			d.coeffs[i][j] = d.field.Mul(d.coeffs[i][j], inv)
+		}
+
+		for j := 0; j < int(d.coded.Cols()); j++ {
+			d.coded[i][j] = d.field.Mul(d.coded[i][j], inv)
+		}
+	}
+}
+
+func (d *DecoderState) remove_zero_rows() {
+	var (
+		cols = len(d.coeffs[0])
+	)
+
+	for i := 0; i < len(d.coeffs); i++ {
+		yes := true
+		for j := 0; j < cols; j++ {
+			if d.coeffs[i][j] != 0 {
+				yes = false
+				break
+			}
+		}
+		if !yes {
+			continue
+		}
+
+		// resize `coeffs` matrix
+		d.coeffs[i] = nil
+		copy((d.coeffs)[i:], (d.coeffs)[i+1:])
+		d.coeffs = (d.coeffs)[:len(d.coeffs)-1]
+
+		// resize `coded` matrix
+		d.coded[i] = nil
+		copy((d.coded)[i:], (d.coded)[i+1:])
+		d.coded = (d.coded)[:len(d.coded)-1]
+
+		i = i - 1
+	}
+}
+
+// Calculates Reduced Row Echelon Form of coefficient
+// matrix, while also modifying coded piece matrix
+// First it forward, backward cleans up matrix
+// i.e. cells other than pivots are zeroed,
+// later it checks if some rows of coefficient matrix
+// are linearly dependent or not, if yes it removes those,
+// while respective rows of coded piece matrix is also
+// removed --- considered to be `not useful piece`
+//
+// Note: All operations are in-place, no more memory
+// allocations are performed
+func (d *DecoderState) Rref() {
+	d.clean_forward()
+	d.clean_backward()
+	d.remove_zero_rows()
+}
+
+// Expected to be invoked after RREF-ed, in other words
+// it won't rref matrix first to calculate rank,
+// rather that needs to first invoked
+func (d *DecoderState) Rank() uint {
+	return d.coeffs.Rows()
+}
+
+func (d *DecoderState) CoefficientMatrix() Matrix {
+	return d.coeffs
+}
+
+func (d *DecoderState) CodedPieceMatrix() Matrix {
+	return d.coded
+}
+
+func NewDecoderState(gf *galoisfield.GF, coeffs, coded [][]byte) *DecoderState {
+	return &DecoderState{field: gf, coeffs: coeffs, coded: coded}
+}

--- a/matrix/decoder_state.go
+++ b/matrix/decoder_state.go
@@ -41,9 +41,18 @@ func (d *DecoderState) clean_forward() {
 				continue
 			}
 
-			tmp := d.coeffs[i]
-			d.coeffs[i] = d.coeffs[pivot]
-			d.coeffs[pivot] = tmp
+			// row switching in coefficient matrix
+			{
+				tmp := d.coeffs[i]
+				d.coeffs[i] = d.coeffs[pivot]
+				d.coeffs[pivot] = tmp
+			}
+			// row switching in coded piece matrix
+			{
+				tmp := d.coded[i]
+				d.coded[i] = d.coded[pivot]
+				d.coded[pivot] = tmp
+			}
 		}
 
 		for j := i + 1; j < rows; j++ {
@@ -56,7 +65,7 @@ func (d *DecoderState) clean_forward() {
 				d.coeffs[j][k] = d.field.Add(d.coeffs[j][k], d.field.Mul(d.coeffs[i][k], quotient))
 			}
 
-			for k := 0; k < int(d.coded.Cols()); k++ {
+			for k := 0; k < len(d.coded[0]); k++ {
 				d.coded[j][k] = d.field.Add(d.coded[j][k], d.field.Mul(d.coded[i][k], quotient))
 			}
 		}
@@ -85,7 +94,7 @@ func (d *DecoderState) clean_backward() {
 				d.coeffs[j][k] = d.field.Add(d.coeffs[j][k], d.field.Mul(d.coeffs[i][k], quotient))
 			}
 
-			for k := 0; k < int(d.coded.Cols()); k++ {
+			for k := 0; k < len(d.coded[0]); k++ {
 				d.coded[j][k] = d.field.Add(d.coded[j][k], d.field.Mul(d.coded[i][k], quotient))
 			}
 
@@ -105,7 +114,7 @@ func (d *DecoderState) clean_backward() {
 			d.coeffs[i][j] = d.field.Mul(d.coeffs[i][j], inv)
 		}
 
-		for j := 0; j < int(d.coded.Cols()); j++ {
+		for j := 0; j < len(d.coded[0]); j++ {
 			d.coded[i][j] = d.field.Mul(d.coded[i][j], inv)
 		}
 	}
@@ -182,7 +191,7 @@ func (d *DecoderState) CodedPieceMatrix() Matrix {
 // i.e. read pieces
 func (d *DecoderState) AddPiece(codedPiece *kodr.CodedPiece) {
 	d.coeffs = append(d.coeffs, codedPiece.Vector)
-	d.coded = append(d.coeffs, codedPiece.Piece)
+	d.coded = append(d.coded, codedPiece.Piece)
 }
 
 // Request decoded piece by index ( 0 based, definitely )

--- a/matrix/matrix.go
+++ b/matrix/matrix.go
@@ -7,6 +7,8 @@ import (
 
 type Matrix [][]byte
 
+// Cell by cell value comparision of two matrices, which
+// returns `true` only if all cells are found to be equal
 func (m *Matrix) Cmp(m_ Matrix) bool {
 	if m.Rows() != m_.Rows() || m.Cols() != m_.Cols() {
 		return false
@@ -22,148 +24,23 @@ func (m *Matrix) Cmp(m_ Matrix) bool {
 	return true
 }
 
+// #-of rows in matrix
+//
+// This may change in runtime, when some rows are removed
+// as they're found to be linearly dependent with some other
+// row, after application of RREF
 func (m *Matrix) Rows() uint {
 	return uint(len(*m))
 }
 
+// #-of columns in matrix
+//
+// This isn't expected to change after initialised
 func (m *Matrix) Cols() uint {
 	return uint(len((*m)[0]))
 }
 
-func (m *Matrix) scale(idx int, scalar byte, field *galoisfield.GF) []byte {
-	nRow := make([]byte, len((*m)[idx]))
-	for i := 0; i < len((*m)[idx]); i++ {
-		nRow[i] = field.Mul((*m)[idx][i], scalar)
-	}
-	return nRow
-}
-
-func (m *Matrix) invert(idx int, field *galoisfield.GF) []byte {
-	for i := 0; i < len((*m)[idx]); i++ {
-		if (*m)[idx][i] != 0 {
-			factor := field.Div(1, (*m)[idx][i])
-			return m.scale(idx, factor, field)
-		}
-	}
-	return (*m)[idx]
-}
-
-func (m *Matrix) pivot(idx int) int {
-	for i := 0; i < len((*m)[idx]); i++ {
-		if (*m)[idx][i] == 1 {
-			return i
-		}
-	}
-	return -1
-}
-
-func add(a, b []byte, field *galoisfield.GF) []byte {
-	c := make([]byte, len(a))
-	for i := range a {
-		c[i] = field.Add(a[i], b[i])
-	}
-	return c
-}
-
-func (m *Matrix) swap(i, j int) {
-	tmp := make([]byte, len((*m)[i]))
-	copy(tmp, (*m)[i])
-	(*m)[i] = (*m)[j]
-	(*m)[j] = tmp
-}
-
-func (m *Matrix) reorder() {
-	for i := 0; i < int(m.Rows()); i++ {
-		pivot_i := m.pivot(i)
-
-		for j := i + 1; j < int(m.Rows()); j++ {
-			pivot_j := m.pivot(j)
-			if pivot_i > pivot_j || pivot_i == -1 {
-				m.swap(i, j)
-				i -= 1
-				break
-			}
-		}
-	}
-}
-
-func (m *Matrix) zeroRow(row int) bool {
-	yes := true
-	for i := 0; i < int(m.Cols()); i++ {
-		if (*m)[row][i] != 0 {
-			return false
-		}
-	}
-	return yes
-}
-
-func (m *Matrix) clean() {
-	for i := 0; i < int(m.Rows()); i++ {
-		if m.zeroRow(i) {
-			(*m)[i] = nil
-			copy((*m)[i:], (*m)[i+1:])
-			*m = (*m)[:len(*m)-1]
-			i = i - 1
-		}
-	}
-}
-
-// Rref - Get matrix into reduced row echelon form, where
-// matrix elements are GF(2**8) element, which are good fit
-// for representing in 1 byte
-func (m *Matrix) Rref(field *galoisfield.GF) {
-	// no need to rref on single row matrix
-	if m.Rows() < 2 {
-		return
-	}
-
-	for i := range *m {
-		row := m.invert(i, field)
-		copy((*m)[i], row)
-		idx := m.pivot(i)
-		if idx == -1 {
-			continue
-		}
-
-		for j := range *m {
-			if i == j || (*m)[j][idx] == 0 {
-				continue
-			}
-
-			copy((*m)[j], add(m.scale(i, (*m)[j][idx], field), (*m)[j], field))
-		}
-	}
-
-	m.clean()
-	m.reorder()
-}
-
-// Rank_ - Expected to be invoked on row reduced matrix
-// so that rref step can be skipped
-//
-// If you've a matrix which is not yet rref-ed, you may want
-// to invoke `Rank()`
-func (m *Matrix) Rank_() uint {
-	var count uint
-	for i := range *m {
-		for j := range *m {
-			if (*m)[i][j] == 1 {
-				count += 1
-				break
-			}
-		}
-	}
-	return count
-}
-
-// Rank - Make use of this method when you've a
-// matrix which is not yet rref-ed
-func (m *Matrix) Rank(field *galoisfield.GF) uint {
-	m.Rref(field)
-	return m.Rank_()
-}
-
-// Multiply - Multiplies two matrices ( which can be multiplied )
+// Multiplies two matrices ( which can be multiplied )
 // in order `m x with`
 func (m *Matrix) Multiply(field *galoisfield.GF, with Matrix) (Matrix, error) {
 	if m.Cols() != with.Rows() {

--- a/matrix/matrix_bench_test.go
+++ b/matrix/matrix_bench_test.go
@@ -9,11 +9,15 @@ import (
 	"github.com/itzmeanjan/kodr/matrix"
 )
 
-func random_matrix(rows, cols int) [][]byte {
+// Note: If fill_with_zero is set, it's not really a random matrix
+func random_matrix(rows, cols int, fill_with_zero bool) [][]byte {
 	mat := make([][]byte, 0, rows)
 	for i := 0; i < rows; i++ {
 		row := make([]byte, cols)
-		rand.Read(row)
+		// already filled with zero
+		if !fill_with_zero {
+			rand.Read(row)
+		}
 		mat = append(mat, row)
 	}
 	return mat
@@ -37,11 +41,13 @@ func BenchmarkMatrixRref(b *testing.B) {
 
 func rref(b *testing.B, dim int, gf *galoisfield.GF) {
 	b.ResetTimer()
-	b.SetBytes(int64(dim * dim))
+	b.SetBytes(int64(dim*dim) << 1)
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		m := matrix.Matrix(random_matrix(dim, dim))
-		m.Rref(gf)
+		coeffs := random_matrix(dim, dim, false)
+		coded := random_matrix(dim, dim, true)
+		d_state := matrix.NewDecoderState(gf, coeffs, coded)
+		d_state.Rref()
 	}
 }

--- a/matrix/matrix_bench_test.go
+++ b/matrix/matrix_bench_test.go
@@ -1,0 +1,47 @@
+package matrix_test
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/cloud9-tools/go-galoisfield"
+	"github.com/itzmeanjan/kodr/matrix"
+)
+
+func random_matrix(rows, cols int) [][]byte {
+	mat := make([][]byte, 0, rows)
+	for i := 0; i < rows; i++ {
+		row := make([]byte, cols)
+		rand.Read(row)
+		mat = append(mat, row)
+	}
+	return mat
+}
+
+func BenchmarkMatrixRref(b *testing.B) {
+	rand.Seed(time.Now().UnixNano())
+	gf := galoisfield.DefaultGF256
+
+	b.Run("2x2", func(b *testing.B) { rref(b, 1<<1, gf) })
+	b.Run("4x4", func(b *testing.B) { rref(b, 1<<2, gf) })
+	b.Run("8x8", func(b *testing.B) { rref(b, 1<<3, gf) })
+	b.Run("16x16", func(b *testing.B) { rref(b, 1<<4, gf) })
+	b.Run("32x32", func(b *testing.B) { rref(b, 1<<5, gf) })
+	b.Run("64x64", func(b *testing.B) { rref(b, 1<<6, gf) })
+	b.Run("128x128", func(b *testing.B) { rref(b, 1<<7, gf) })
+	b.Run("256x256", func(b *testing.B) { rref(b, 1<<8, gf) })
+	b.Run("512x512", func(b *testing.B) { rref(b, 1<<9, gf) })
+	b.Run("1024x1024", func(b *testing.B) { rref(b, 1<<10, gf) })
+}
+
+func rref(b *testing.B, dim int, gf *galoisfield.GF) {
+	b.ResetTimer()
+	b.SetBytes(int64(dim * dim))
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		m := matrix.Matrix(random_matrix(dim, dim))
+		m.Rref(gf)
+	}
+}

--- a/matrix/matrix_test.go
+++ b/matrix/matrix_test.go
@@ -13,44 +13,81 @@ import (
 func TestMatrixRref(t *testing.T) {
 	field := galoisfield.DefaultGF256
 
-	m_1 := matrix.Matrix{{70, 137, 2, 152}, {223, 92, 234, 98}, {217, 141, 33, 44}, {145, 135, 71, 45}}
-	m_1_rref := matrix.Matrix{{1, 0, 0, 105}, {0, 1, 0, 181}, {0, 0, 1, 42}}
-	m_1.Rref(field)
-	if !m_1.Cmp(m_1_rref) {
-		t.Fatal("rref doesn't match !")
+	{
+		m := matrix.Matrix{{70, 137, 2, 152}, {223, 92, 234, 98}, {217, 141, 33, 44}, {145, 135, 71, 45}}
+		m_rref := matrix.Matrix{{1, 0, 0, 105}, {0, 1, 0, 181}, {0, 0, 1, 42}}
+		coded := matrix.Matrix{{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}}
+
+		dec := matrix.NewDecoderState(field, m, coded)
+		dec.Rref()
+		res := dec.CoefficientMatrix()
+		if !res.Cmp(m_rref) {
+			t.Fatal("rref doesn't match !")
+		}
 	}
 
-	m_2 := matrix.Matrix{{68, 54, 6, 230}, {16, 56, 215, 78}, {159, 186, 146, 163}, {122, 41, 205, 133}}
-	m_2_rref := matrix.Matrix{{1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}}
-	m_2.Rref(field)
-	if !m_2.Cmp(m_2_rref) {
-		t.Fatal("rref doesn't match !")
+	{
+		m := matrix.Matrix{{68, 54, 6, 230}, {16, 56, 215, 78}, {159, 186, 146, 163}, {122, 41, 205, 133}}
+		m_rref := matrix.Matrix{{1, 0, 0, 0}, {0, 1, 0, 0}, {0, 0, 1, 0}, {0, 0, 0, 1}}
+		coded := matrix.Matrix{{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}}
+
+		dec := matrix.NewDecoderState(field, m, coded)
+		dec.Rref()
+		res := dec.CoefficientMatrix()
+		if !res.Cmp(m_rref) {
+			t.Fatal("rref doesn't match !")
+		}
 	}
 
-	m_3 := matrix.Matrix{{100, 31, 76, 199, 119}, {207, 34, 207, 208, 18}, {62, 20, 54, 6, 187}, {66, 8, 52, 73, 54}, {122, 138, 247, 211, 165}}
-	m_3_rref := matrix.Matrix{{1, 0, 0, 0, 0}, {0, 1, 0, 0, 0}, {0, 0, 1, 0, 0}, {0, 0, 0, 1, 0}, {0, 0, 0, 0, 1}}
-	m_3.Rref(field)
-	if !m_3.Cmp(m_3_rref) {
-		t.Fatal("rref doesn't match !")
+	{
+		m := matrix.Matrix{{100, 31, 76, 199, 119}, {207, 34, 207, 208, 18}, {62, 20, 54, 6, 187}, {66, 8, 52, 73, 54}, {122, 138, 247, 211, 165}}
+		m_rref := matrix.Matrix{{1, 0, 0, 0, 0}, {0, 1, 0, 0, 0}, {0, 0, 1, 0, 0}, {0, 0, 0, 1, 0}, {0, 0, 0, 0, 1}}
+		coded := matrix.Matrix{{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}}
+
+		dec := matrix.NewDecoderState(field, m, coded)
+		dec.Rref()
+		res := dec.CoefficientMatrix()
+		if !res.Cmp(m_rref) {
+			t.Fatal("rref doesn't match !")
+		}
 	}
 }
 
 func TestMatrixRank(t *testing.T) {
 	field := galoisfield.DefaultGF256
 
-	m_1 := matrix.Matrix{{70, 137, 2, 152}, {223, 92, 234, 98}, {217, 141, 33, 44}, {145, 135, 71, 45}}
-	if rank := m_1.Rank(field); rank != 3 {
-		t.Fatalf("expected rank 3, received %d", rank)
+	{
+		m := matrix.Matrix{{70, 137, 2, 152}, {223, 92, 234, 98}, {217, 141, 33, 44}, {145, 135, 71, 45}}
+		coded := matrix.Matrix{{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}}
+
+		dec := matrix.NewDecoderState(field, m, coded)
+		dec.Rref()
+		if rank := dec.Rank(); rank != 3 {
+			t.Fatalf("expected rank 3, received %d", rank)
+		}
 	}
 
-	m_2 := matrix.Matrix{{68, 54, 6, 230}, {16, 56, 215, 78}, {159, 186, 146, 163}, {122, 41, 205, 133}}
-	if rank := m_2.Rank(field); rank != 4 {
-		t.Fatalf("expected rank 4, received %d", rank)
+	{
+
+		m := matrix.Matrix{{68, 54, 6, 230}, {16, 56, 215, 78}, {159, 186, 146, 163}, {122, 41, 205, 133}}
+		coded := matrix.Matrix{{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}}
+
+		dec := matrix.NewDecoderState(field, m, coded)
+		dec.Rref()
+		if rank := dec.Rank(); rank != 4 {
+			t.Fatalf("expected rank 4, received %d", rank)
+		}
 	}
 
-	m_3 := matrix.Matrix{{100, 31, 76, 199, 119}, {207, 34, 207, 208, 18}, {62, 20, 54, 6, 187}, {66, 8, 52, 73, 54}, {122, 138, 247, 211, 165}}
-	if rank := m_3.Rank(field); rank != 5 {
-		t.Fatalf("expected rank 5, received %d", rank)
+	{
+		m := matrix.Matrix{{100, 31, 76, 199, 119}, {207, 34, 207, 208, 18}, {62, 20, 54, 6, 187}, {66, 8, 52, 73, 54}, {122, 138, 247, 211, 165}}
+		coded := matrix.Matrix{{0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}, {0, 0, 0, 0}}
+
+		dec := matrix.NewDecoderState(field, m, coded)
+		dec.Rref()
+		if rank := dec.Rank(); rank != 5 {
+			t.Fatalf("expected rank 5, received %d", rank)
+		}
 	}
 }
 

--- a/systematic/decoder.go
+++ b/systematic/decoder.go
@@ -82,9 +82,10 @@ func (s *SystematicRLNCDecoder) GetPieces() ([]kodr.Piece, error) {
 
 	pieces := make([]kodr.Piece, 0, s.useful)
 	for i := 0; i < int(s.useful); i++ {
-		// safe to ignore error, because I've
-		// already checked it above
-		piece, _ := s.GetPiece(uint(i))
+		piece, err := s.GetPiece(uint(i))
+		if err != nil {
+			return nil, err
+		}
 		pieces = append(pieces, piece)
 	}
 	return pieces, nil

--- a/systematic/decoder.go
+++ b/systematic/decoder.go
@@ -8,14 +8,20 @@ import (
 
 type SystematicRLNCDecoder struct {
 	expected, useful, received uint
-	field                      *galoisfield.GF
-	pieces                     []*kodr.CodedPiece
-	rref                       matrix.Matrix
+	state                      *matrix.DecoderState
 }
 
 // Each piece of N-many bytes
+//
+// Note: If no pieces are yet added to decoder state, then
+// returns 0, denoting **unknown**
 func (s *SystematicRLNCDecoder) PieceLength() uint {
-	return uint(len(s.pieces[0].Piece))
+	if s.received > 0 {
+		coded := s.state.CodedPieceMatrix()
+		return coded.Cols()
+	}
+
+	return 0
 }
 
 // Already decoded back to original pieces, with collected pieces ?
@@ -39,44 +45,33 @@ func (s *SystematicRLNCDecoder) Required() uint {
 // If all required pieces are already collected i.e. successful decoding
 // has happened --- new pieces to be discarded, with an error denoting same
 func (s *SystematicRLNCDecoder) AddPiece(piece *kodr.CodedPiece) error {
-	s.pieces = append(s.pieces, piece)
+	if s.IsDecoded() {
+		return kodr.ErrAllUsefulPiecesReceived
+	}
+
+	s.state.AddPiece(piece)
 	s.received++
 	if !(s.received > 1) {
 		s.useful++
 		return nil
 	}
-	// no more piece collection is required, decoding
-	// has been performed successfully
-	//
-	// good time to start reading decoded pieces
-	if s.IsDecoded() {
-		return kodr.ErrAllUsefulPiecesReceived
-	}
 
-	if s.rref == nil {
-		rref := make(matrix.Matrix, s.received)
-		for i := range rref {
-			rref[i] = s.pieces[i].Flatten()
-		}
-
-		s.rref = rref
-	} else {
-		s.rref = append(s.rref, piece.Flatten())
-	}
-
-	s.rref.Rref(s.field)
-	s.useful = s.rref.Rank_()
+	s.state.Rref()
+	s.useful = s.state.Rank()
 	return nil
 }
 
-// After full decoding has happened, this method can be used for finding
-// i-th original piece, among N-pieces coded together --- so i < N, always
+// GetPiece - Get a decoded piece by index, may ( not ) succeed !
+//
+// Note: It's not necessary that full decoding needs to happen
+// for this method to return something useful
+//
+// If M-many pieces are received among N-many expected ( read M <= N )
+// then pieces with index in [0..M] ( remember upper bound exclusive )
+// can be attempted to be consumed, given algebric structure has revealed
+// requested piece at index `i`
 func (s *SystematicRLNCDecoder) GetPiece(i uint) (kodr.Piece, error) {
-	if !s.IsDecoded() || i >= s.useful {
-		return nil, kodr.ErrMoreUsefulPiecesRequired
-	}
-
-	return s.rref[i][uint(len(s.rref[i]))-s.PieceLength():], nil
+	return s.state.GetPiece(i)
 }
 
 // All original pieces in order --- only when full decoding has happened
@@ -95,7 +90,7 @@ func (s *SystematicRLNCDecoder) GetPieces() ([]kodr.Piece, error) {
 	return pieces, nil
 }
 
-// Pieces coded by systematic mean, alogn with randomly coded pieces,
+// Pieces coded by systematic mean, along with randomly coded pieces,
 // are decoded with this decoder
 //
 // @note Actually FullRLNCDecoder could have been used for same purpose
@@ -105,5 +100,7 @@ func (s *SystematicRLNCDecoder) GetPieces() ([]kodr.Piece, error) {
 // systematic coded pieces ( vectors )/ removing this
 // in some future date
 func NewSystematicRLNCDecoder(pieceCount uint) *SystematicRLNCDecoder {
-	return &SystematicRLNCDecoder{expected: pieceCount, field: galoisfield.DefaultGF256, pieces: make([]*kodr.CodedPiece, 0)}
+	gf := galoisfield.DefaultGF256
+	state := matrix.NewDecoderStateWithPieceCount(gf, pieceCount)
+	return &SystematicRLNCDecoder{expected: pieceCount, state: state}
 }


### PR DESCRIPTION
## What's new ?

For decoding coded pieces, coding coefficient matrix is converted into **R**educed **R**ow **E**chelon **F**orm, everytime new piece arrives --- I attempt to improve `rref` implementation by making mutation in-place ( reduction in memory allocation ), resulting into **>=2x** speed up.

![out](https://user-images.githubusercontent.com/45074836/128623992-170bb67c-847a-43f5-b763-92cd616385a3.png)

I do benchmark comparison of old & new implementations 

```bash
$ benchcmp new.txt old.txt 

benchmark                           old ns/op      new ns/op      delta
BenchmarkMatrixRref/2x2-8           264            270            +2.35%
BenchmarkMatrixRref/4x4-8           568            869            +53.02%
BenchmarkMatrixRref/8x8-8           2269           3909           +72.28%
BenchmarkMatrixRref/16x16-8         13208          22458          +70.03%
BenchmarkMatrixRref/32x32-8         92794          129114         +39.14%
BenchmarkMatrixRref/64x64-8         681918         848751         +24.47%
BenchmarkMatrixRref/128x128-8       5568454        6064303        +8.90%
BenchmarkMatrixRref/256x256-8       43729678       44994637       +2.89%
BenchmarkMatrixRref/512x512-8       333661594      344285636      +3.18%
BenchmarkMatrixRref/1024x1024-8     2654513014     2825216190     +6.43%

benchmark                           old MB/s     new MB/s     speedup
BenchmarkMatrixRref/2x2-8           30.33        14.81        0.49x
BenchmarkMatrixRref/4x4-8           56.33        18.41        0.33x
BenchmarkMatrixRref/8x8-8           56.41        16.37        0.29x
BenchmarkMatrixRref/16x16-8         38.76        11.40        0.29x
BenchmarkMatrixRref/32x32-8         22.07        7.93         0.36x
BenchmarkMatrixRref/64x64-8         12.01        4.83         0.40x
BenchmarkMatrixRref/128x128-8       5.88         2.70         0.46x
BenchmarkMatrixRref/256x256-8       3.00         1.46         0.49x
BenchmarkMatrixRref/512x512-8       1.57         0.76         0.48x
BenchmarkMatrixRref/1024x1024-8     0.79         0.37         0.47x

benchmark                           old allocs     new allocs     delta
BenchmarkMatrixRref/2x2-8           6              8              +33.33%
BenchmarkMatrixRref/4x4-8           10             32             +220.00%
BenchmarkMatrixRref/8x8-8           18             128            +611.11%
BenchmarkMatrixRref/16x16-8         34             510            +1400.00%
BenchmarkMatrixRref/32x32-8         66             2040           +2990.91%
BenchmarkMatrixRref/64x64-8         130            8160           +6176.92%
BenchmarkMatrixRref/128x128-8       258            32639          +12550.78%
BenchmarkMatrixRref/256x256-8       514            130567         +25302.14%
BenchmarkMatrixRref/512x512-8       1026           522223         +50798.93%
BenchmarkMatrixRref/1024x1024-8     2050           2089044        +101804.59%

benchmark                           old bytes     new bytes      delta
BenchmarkMatrixRref/2x2-8           104           63             -39.42%
BenchmarkMatrixRref/4x4-8           224           223            -0.45%
BenchmarkMatrixRref/8x8-8           512           1211           +136.52%
BenchmarkMatrixRref/16x16-8         1280          8543           +567.42%
BenchmarkMatrixRref/32x32-8         3584          66043          +1742.72%
BenchmarkMatrixRref/64x64-8         11264         523754         +4549.80%
BenchmarkMatrixRref/128x128-8       38912         4180774        +10644.18%
BenchmarkMatrixRref/256x256-8       143360        33430985       +23219.60%
BenchmarkMatrixRref/512x512-8       548864        267387738      +48616.57%
BenchmarkMatrixRref/1024x1024-8     2146304       2139164576     +99567.36%
```